### PR TITLE
fixes GetManagedObjects() failed: org.freedesktop.DBus.Error.AccessDe…

### DIFF
--- a/BluetoothSpeaker.md
+++ b/BluetoothSpeaker.md
@@ -14,6 +14,7 @@
   	
     apt-get update
     apt-get install bluez pulseaudio-module-bluetooth python-gobject python-gobject-2
+    usermod -a -G lp myusername
 #### Check And Pair Bluetooth
   check cmds:
   

--- a/BluetoothSpeaker.md
+++ b/BluetoothSpeaker.md
@@ -14,7 +14,7 @@
   	
     apt-get update
     apt-get install bluez pulseaudio-module-bluetooth python-gobject python-gobject-2
-    usermod -a -G lp myusername
+    usermod -a -G lp `whoami`
 #### Check And Pair Bluetooth
   check cmds:
   


### PR DESCRIPTION
…nied: Rejected send message, 2 matched rules; type="method_call",  interface="org.freedesktop.DBus.ObjectManager" member="GetManagedObjects" error name="(unset)" requested_reply="0" destination="org.bluez" comm="/usr/lib/bluetooth/bluetoothd"
